### PR TITLE
Refactor: Integrate with rhythmic-rituals-api server

### DIFF
--- a/fastapi_template/README.md
+++ b/fastapi_template/README.md
@@ -8,39 +8,46 @@ Academic researchers and knowledge workers need rapid idea capture without frict
 ## The Solution
 - **Rapid Capture**: Dump any thought in 2 seconds
 - **Priority Focus**: See your most important task instantly  
-- **Goal Hierarchy**: Projects → Milestones → Tasks
-- **Your Data**: Everything lives in your Notion workspace
+- **Goal Hierarchy**: Projects → Milestones → Tasks (Managed by backend API)
+- **Your Data**: Data is managed by a backend service, accessible via this portal.
 
 ## Philosophy
 **Elegant Simplicity**: One input field. One priority task. Zero cognitive overhead.
 
 ---
 
-## 🚀 Setup (2 minutes)
+## ⚙️ Configuration
 
-### 1. Run Setup
+This application connects to a backend API to manage data. You need to configure the following environment variable:
+
+*   `API_BASE_URL`: The base URL of the rhythmic-rituals-api server (e.g., `https://your-api-server.com/api`).
+
+Set this environment variable before running the application. For example, you can create a `.env` file in the project root:
+```
+API_BASE_URL=https://your-api-server.com/api
+```
+Or set it in your shell:
 ```bash
-python setup.py
+export API_BASE_URL="https://your-api-server.com/api"
 ```
 
-This will:
-- Install dependencies
-- Guide you through Notion integration
-- Create required databases
-- Generate your `.env` file
+## 🚀 Launch
 
-### 2. Share Databases
-In Notion, share each created database with your integration:
-- 📝 Ideas & Entries  
-- 🏆 Projects
-- 📍 Milestones
-- ✅ Tasks
+1.  **Install dependencies**:
+    ```bash
+    pip install -r requirements.txt
+    ```
+2.  **Set `API_BASE_URL`**: Ensure the environment variable is set as described above.
+3.  **Run the application**:
+    ```bash
+    python -m uvicorn fastapi_template.main:app --reload
+    ```
+    Or if you have `main.py` in the root and adjust imports:
+    ```bash
+    python main.py
+    ```
+    Visit `http://localhost:8000` (or the port specified by uvicorn).
 
-### 3. Launch
-```bash
-python main.py
-```
-Visit `http://localhost:8000`
 
 ---
 
@@ -58,24 +65,25 @@ Visit `http://localhost:8000`
 4. **Repeat**: Let the system surface what matters next
 
 **The Data Flow:**
-- Every capture → Notion "Ideas & Entries" database
-- Projects → Structured in Notion with milestones and tasks
-- Priority algorithm → Surfaces most important incomplete task
-- Your workspace → All data accessible in Notion forever
+- Every capture → Sent to the backend API.
+- Projects → Managed via the backend API.
+- Priority algorithm → Handled by the backend API.
+- Your data → Accessible through this portal, managed by the backend service.
 
 ---
 
-## 📁 Architecture (3 files)
+## 📁 Architecture
 
+This FastAPI application serves as a user interface for a productivity portal. It communicates with an external API (specified by `API_BASE_URL`) which in turn manages the data persistence, potentially using Notion or other services.
 
+The main components are:
 ```
-main.py      # Single-file FastAPI app with embedded HTML/CSS/JS
-notion.py    # Notion database integration
-setup.py     # One-command setup script
-README.md    # This file
+fastapi_template/main.py  # FastAPI application, serves HTML and API routes
+fastapi_template/notion.py # APIClient for communicating with the backend server
+requirements.txt          # Python dependencies
+README.md                 # This file
 ```
-
-**Total Lines**: ~350 lines across 4 files
+The application is designed to be lightweight and focused on providing a swift user experience, while delegating data management to a dedicated backend service.
 
 ---
 
@@ -85,7 +93,7 @@ README.md    # This file
 
 **Speed Over Polish**: Get thoughts captured in 2 seconds, not 20.
 
-**Your Data**: Notion as backend means you own everything forever.
+**Your Data**: Data is managed by the backend API, providing flexibility in storage.
 
 **Zero Lock-in**: Standard web technologies. Fork it. Modify it. Own it.
 

--- a/fastapi_template/requirements.txt
+++ b/fastapi_template/requirements.txt
@@ -1,4 +1,3 @@
-fastapi==0.104.1
-uvicorn==0.24.0
-notion-client==2.3.0
-python-dotenv==1.0.0
+fastapi
+uvicorn[standard]
+requests

--- a/fastapi_template/test_apiclient.py
+++ b/fastapi_template/test_apiclient.py
@@ -1,0 +1,152 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import os
+from fastapi import HTTPException
+from typing import Optional, List, Dict
+
+# Assuming test_apiclient.py is in the same directory as notion.py (which contains APIClient)
+# For the subtask environment, let's be explicit:
+# If notion.py is in fastapi_template, and test_apiclient.py is also in fastapi_template:
+from .notion import APIClient
+import requests # Import at the top level for exception types
+
+class TestAPIClient(unittest.TestCase):
+
+    @patch.dict(os.environ, {"API_BASE_URL": "http://testapi.com"})
+    def setUp(self):
+        self.client = APIClient()
+
+    @patch('fastapi_template.notion.requests.request') # Patch where requests is used
+    def test_get_entries_success(self, mock_request):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = [
+            {"id": "1", "title": "Test Entry 1", "content": "Content 1", "last_edited_time": "2023-01-01T12:00:00Z"},
+            {"id": "2", "title": "Test Entry 2", "content": "Content 2", "last_edited_time": "2023-01-02T12:00:00Z"}
+        ]
+        mock_request.return_value = mock_response
+
+        entries = self.client.get_entries()
+        self.assertEqual(len(entries), 2)
+        self.assertEqual(entries[0]["id"], "1")
+        self.assertEqual(entries[0]["content"], "Content 1") # APIClient maps 'content' or 'title'
+        self.assertEqual(entries[0]["created_at"], "2023-01-01T12:00:00Z") # APIClient maps 'last_edited_time'
+        mock_request.assert_called_once_with("GET", "http://testapi.com/api/notes", json=None, timeout=10)
+
+    @patch('fastapi_template.notion.requests.request')
+    def test_create_entry_success(self, mock_request):
+        mock_response = MagicMock()
+        mock_response.status_code = 201 # Typically 201 for created
+        mock_response.json.return_value = {"id": "new_id", "message": "Note added successfully"}
+        mock_request.return_value = mock_response
+
+        entry_data = self.client.create_entry(content="New test entry")
+        self.assertEqual(entry_data["id"], "new_id")
+        self.assertEqual(entry_data["message"], "Note added successfully")
+        # APIClient sends 'title' (first 100 chars of content) and 'content'
+        expected_payload = {"title": "New test entry"[:100], "content": "New test entry"}
+        mock_request.assert_called_once_with("POST", "http://testapi.com/api/notes", json=expected_payload, timeout=10)
+
+    @patch('fastapi_template.notion.requests.request')
+    def test_get_projects_success(self, mock_request):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = [
+            {"id": "p1", "name": "Project Alpha", "description": "Desc Alpha", "deadline": "2024-12-31"}
+        ]
+        mock_request.return_value = mock_response
+
+        projects = self.client.get_projects()
+        self.assertEqual(len(projects), 1)
+        self.assertEqual(projects[0]["name"], "Project Alpha")
+        mock_request.assert_called_once_with("GET", "http://testapi.com/api/projects", json=None, timeout=10)
+
+    @patch('fastapi_template.notion.requests.request')
+    def test_create_project_success(self, mock_request):
+        mock_response = MagicMock()
+        mock_response.status_code = 201 # Typically 201 for created
+        mock_response.json.return_value = {"id": "new_project_id", "message": "Project created"}
+        mock_request.return_value = mock_response
+
+        project_data = self.client.create_project(name="New Project", description="A cool new project", deadline="2025-01-01")
+        self.assertEqual(project_data["id"], "new_project_id")
+        expected_payload = {"name": "New Project", "description": "A cool new project", "deadline": "2025-01-01"}
+        mock_request.assert_called_once_with("POST", "http://testapi.com/api/projects", json=expected_payload, timeout=10)
+
+    @patch('fastapi_template.notion.requests.request')
+    def test_get_priority_task_success(self, mock_request):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"id": "task1", "name": "Important Task", "description": "Do this first"}
+        mock_request.return_value = mock_response
+
+        task = self.client.get_priority_task()
+        self.assertIsNotNone(task)
+        self.assertEqual(task["name"], "Important Task")
+        mock_request.assert_called_once_with("GET", "http://testapi.com/api/priority-task", json=None, timeout=10)
+
+    @patch('fastapi_template.notion.requests.request')
+    def test_get_priority_task_no_tasks_message(self, mock_request): # Renamed for clarity
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"message": "No tasks available"} # As handled by APIClient
+        mock_request.return_value = mock_response
+
+        task = self.client.get_priority_task()
+        self.assertIsNotNone(task)
+        self.assertIn("message", task)
+        mock_request.assert_called_once_with("GET", "http://testapi.com/api/priority-task", json=None, timeout=10)
+
+    @patch('fastapi_template.notion.requests.request')
+    def test_api_http_error_404(self, mock_request): # Be specific in test names
+        mock_http_error_response = MagicMock(spec=requests.Response)
+        mock_http_error_response.status_code = 404
+        mock_http_error_response.reason = "Not Found"
+        mock_http_error_response.text = "Detailed error message from API"
+
+        # The side_effect should be an instance of HTTPError, configured with the mock response
+        http_error_instance = requests.exceptions.HTTPError(response=mock_http_error_response)
+        mock_http_error_response.raise_for_status.side_effect = http_error_instance # Mock raise_for_status behavior
+        mock_request.return_value = mock_http_error_response
+
+
+        with self.assertRaises(HTTPException) as cm:
+            self.client.get_entries() # Any method that uses _request would work
+        self.assertEqual(cm.exception.status_code, 404)
+        self.assertIn("External API HTTP error: 404 Not Found", cm.exception.detail)
+        self.assertIn("Detailed error message from API", cm.exception.detail)
+
+
+    @patch('fastapi_template.notion.requests.request')
+    def test_api_timeout_error(self, mock_request):
+        mock_request.side_effect = requests.exceptions.Timeout("Request timed out")
+
+        with self.assertRaises(HTTPException) as cm:
+            self.client.get_entries()
+        self.assertEqual(cm.exception.status_code, 504) # As defined in APIClient
+        self.assertEqual(cm.exception.detail, "External API request timed out.")
+
+    @patch('fastapi_template.notion.requests.request')
+    def test_api_connection_error(self, mock_request):
+        mock_request.side_effect = requests.exceptions.ConnectionError("Failed to connect")
+
+        with self.assertRaises(HTTPException) as cm:
+            self.client.get_entries()
+        self.assertEqual(cm.exception.status_code, 503) # As defined in APIClient
+        self.assertIn("Service unavailable: Error connecting to external API (ConnectionError)", cm.exception.detail)
+
+    def test_init_no_api_base_url(self):
+        # Temporarily remove the API_BASE_URL for this test case
+        original_api_base_url = os.environ.pop("API_BASE_URL", None)
+        try:
+            with self.assertRaises(ValueError) as cm:
+                APIClient()
+            self.assertEqual(str(cm.exception), "API_BASE_URL environment variable is not set.")
+        finally:
+            # Restore API_BASE_URL if it was originally set
+            if original_api_base_url is not None:
+                os.environ["API_BASE_URL"] = original_api_base_url
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit modifies the application to connect to an external API server (tomxi/rhythmic-rituals-api) instead of directly interacting with the Notion API.

Key changes:

-   **`fastapi_template/notion.py`**: I replaced `NotionDB` with `APIClient`, which uses the `requests` library to communicate with the external API. It requires an `API_BASE_URL` environment variable. I updated methods to align with the expected (or assumed for projects/tasks) API endpoints and data structures of the new server.
-   **`fastapi_template/main.py`**: I updated this file to use `APIClient`. I removed Notion-specific setup (token input, direct NotionDB initialization). I also added a startup event to initialize `APIClient` and error handling if initialization fails.
-   **`fastapi_template/requirements.txt`**: I removed `notion-client` and `python-dotenv`. I added `requests`.
-   **`fastapi_template/README.md`**: I updated setup instructions and the architecture description to reflect the use of the external API server and the `API_BASE_URL` environment variable.
-   **`fastapi_template/test_apiclient.py`**: I added new unit tests for the `APIClient` class, covering successful API interactions and various error conditions.

This change decouples the frontend application from direct Notion API management, allowing for a separate, hosted backend to handle those interactions.